### PR TITLE
Increases stat retention

### DIFF
--- a/graphite/conf/storage-schemas.conf
+++ b/graphite/conf/storage-schemas.conf
@@ -11,6 +11,6 @@
 pattern = ^carbon\.
 retentions = 60:90d
 
-[default_1min_for_1day]
+[default]
 pattern = .*
-retentions = 60s:1d
+retentions = 60s:30d,5m:1y,1h:5y


### PR DESCRIPTION
Changes the retention of stats to:
1 minute intervals for 30 days, 5 minute intervals for 1 year and 1 hour intervals for 5 years.
The files come to 2.2MB which is 22GB in total for the current stats.
