### PR TITLE
Drop WSGIImportScript

### DIFF
--- a/deploy/templates/apache2/vhost.conf.template
+++ b/deploy/templates/apache2/vhost.conf.template
@@ -1,5 +1,3 @@
-WSGIImportScript {{conf.deploy.root}}/graphite/live/graphite.wsgi process-group=graphite application-group=%{GLOBAL}
-
 <VirtualHost *:80>
     ServerName {{aconf.domain}}
 


### PR DESCRIPTION
It breaks on precise, because it's outside the vhost, but the process
group isn't.

It uses the wrong application group, too.
